### PR TITLE
explain citation application to website only

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,10 @@ keywords:
   - EUCP
 repository-code: "https://github.com/eucp-project/data-catalogue"
 license: "Apache-2.0"
-message: "If you use this software, please cite it using these metadata."
+message: >
+  This citation information applies to the data catalogue source code.
+  The content in `/content/` is licensed and authored separately.
+  If you use this software, please cite it using these metadata.
 cff-version: "1.2.0"
 authors:
   -

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,7 @@ license: "Apache-2.0"
 message: >
   This citation information applies to the data catalogue source code.
   The content in `/content/` is licensed and authored separately.
+  See `/content/LICENSE.md` for more information. 
   If you use this software, please cite it using these metadata.
 cff-version: "1.2.0"
 authors:


### PR DESCRIPTION
This PR ensures that the CFF is clear about different licensing and author information between the source code for the web page, and the content by EUCP partners.

CFF format validated with cffconvert:
```
$ cffconvert --validate
Citation metadata are valid according to schema version 1.2.0
```
