### PR TITLE
More styling

### DIFF
--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="fixed top-0 right-0 bottom-0 left-0 flex justify-center bg-gray-900 bg-opacity-80"
+    class="fixed inset-0 h-screen w-screen bg-gray-900 bg-opacity-80"
     @click="$emit('close-modal')"
   >
     <div
-      class="justify-center text-left overflow-auto m-10 p-10 rounded-xl mt-10 bg-white prose max-w-none"
+      class="fixed inset-10 overflow-auto p-10 rounded-xl bg-white prose max-w-none"
       @click.stop
     >
       <button
@@ -13,7 +13,7 @@
       >
         Close
       </button>
-      <h2>{{ dataset.title }}</h2>
+      <h1>{{ dataset.title }}</h1>
       <ul>
         <li>Contact: {{ dataset.contact[0].name }}</li>
         <li>License: {{ dataset.license }}</li>

--- a/components/Navigation.vue
+++ b/components/Navigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative flex ml-auto mr-8">
+  <div class="relative flex gap-2 justify-end w-full mr-8">
     <div
       v-for="(page, i) in pages"
       :key="i"
@@ -11,7 +11,7 @@
       <NuxtLink :to="page.url">
         <button
           class="
-            w-40 mx-1 mt-12 px-3 py-2
+            w-40 mt-12 px-3 py-2
             rounded-t-lg
             bg-gray-100
             text-center
@@ -28,28 +28,27 @@
       <!-- second menu row -->
       <div
         v-if="page.hover | (inActiveRoute(page.url) && !checkHover(page, pages))"
-        class="absolute flex flex-row inset-y-30 right-0 mr-8 pr-6"
+        class="absolute right-0 flex flex-row justify-end h-12 w-full"
       >
-        <div
+        <NuxtLink
           v-for="subPage in page.children"
           :key="subPage"
-        >
-          <NuxtLink :to="subPage.url">
-            <button
-              class="
+          role="button"
+          :to="subPage.url"
+          class="
+                h-full
                 px-8 py-3
                 text-center
                 text-gray-700 hover:underline"
-              :class="{
-                'text-blue-500': inActiveRoute(subPage.url)
-              }"
-            >
-              {{ subPage.title }}
-            </button>
-          </NuxtLink>
-        </div>
+          :class="{
+            'text-blue-500': inActiveRoute(subPage.url)
+          }"
+        >
+          {{ subPage.title }}
+        </NuxtLink>
       </div>
     </div>
+  </div>
   </div>
 </template>
 

--- a/components/Navigation.vue
+++ b/components/Navigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex ml-auto mr-8">
+  <div class="relative flex ml-auto mr-8">
     <div
       v-for="(page, i) in pages"
       :key="i"

--- a/components/Navigation.vue
+++ b/components/Navigation.vue
@@ -2,7 +2,7 @@
   <div class="relative flex gap-2 justify-end w-full mr-8">
     <div
       v-for="(page, i) in pages"
-      :key="i"
+      :key="`parent_${i}`"
       class=""
       @mouseenter="toggleHover(page)"
       @mouseleave="toggleHover(page)"
@@ -31,8 +31,8 @@
         class="absolute right-0 flex flex-row justify-end h-12 w-full"
       >
         <NuxtLink
-          v-for="subPage in page.children"
-          :key="subPage"
+          v-for="(subPage, i) in page.children"
+          :key="`child_${i}`"
           role="button"
           :to="subPage.url"
           class="

--- a/components/cpm/Analysis.vue
+++ b/components/cpm/Analysis.vue
@@ -1,31 +1,56 @@
 <template>
-  <div class="w-full h-full">
-    <p class="m-2 ml-9 text-lg prose">
-      Diurnal cycles of precipitation in summer for the future climate.
-    </p>
-    <p class="m-2 ml-9 text-lg prose">
-      The selected domain is: {{ domain }}
-    </p>
+  <div class="flex flex-col items-stretch w-full h-full">
+    <div class="prose max-w-none p-4">
+      <h1>
+        Diurnal cycles of precipitation in summer for the future climate.
+      </h1>
+    </div>
+    <div class="flex p-4">
+      <div class="prose max-w-none">Select a region:</div>
+      <div class="ml-4"><!-- not prose not working in this version? -->
+        <multiselect
+          v-model="selectedDomain"
+          :options="domains"
+          :allow-empty="false"
+          :close-on-select="true"
+          :show-labels="false"
+          label="name"
+          deselect-label=" "
+          placeholder="Select a region."
+        />
+      </div>
+    </div>
     <div
-      class="bg-no-repeat bg-left-top bg-contain w-1/2 h-full"
+      class="bg-no-repeat bg-left-top bg-contain h-full"
       :style="{backgroundImage: `url(${diurnalCycleImage})` }"
     />
   </div>
 </template>
 
 <script>
+import Multiselect from 'vue-multiselect'
+
 export default {
-  props: {
-    domain: {
-      default: 'AL',
-      type: String
+  components: { Multiselect },
+  data () {
+    return {
+      selectedDomain: { name: 'Alps', code: 'AL' },
+      domains: [
+        { name: 'Alps', code: 'AL' },
+        { name: 'Northern Europe', code: 'N' },
+        { name: 'Northwest Europe', code: 'NW' },
+        { name: 'Central Europe', code: 'C' },
+        { name: 'Central Eastern Europe', code: 'CE' },
+        { name: 'Southwest Europe', code: 'SW' },
+        { name: 'Southeast Europe', code: 'SE' }
+      ]
     }
   },
   computed: {
     diurnalCycleImage () {
       const fallback = 'empty.png'
       try {
-        return require('~/static/cpm_analysis/analyse/' + this.domain + '_future_JJA.png')
+        return require('~/static/cpm_analysis/analyse/' + this.selectedDomain.code + '_future_JJA.png')
       } catch (err) {
         return fallback
       }

--- a/components/cpm/Explore.vue
+++ b/components/cpm/Explore.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full h-full">
-    <span class="flex flex-wrap space-x-3 p-3">
+  <div class="flex flex-col w-full h-full">
+    <span class="flex space-x-3 p-3">
       <div>
         <multiselect
           v-model="selectedVariable"
@@ -90,20 +90,23 @@
       :key="experiment.path"
       class="w-full h-full"
     >
-      <p>{{ experiment.name }}</p>
-      <div class="flex flex-wrap w-full h-full">
+      <div class="flex w-full h-full">
+        <p class="text-lg prose">
+          {{ experiment.name }}:
+        </p>
         <div
           v-for="project in selectedProject"
           :key="project.code"
           class="w-1/3 h-full"
         >
-          <p class="pt-6 text-center text-lg prose">
+          <p class="text-center text-lg prose">
             {{ project.title }}
           </p>
           <div
-            class="bg-no-repeat bg-left-top bg-contain w-full h-full"
+            class="bg-no-repeat bg-contain w-auto h-full"
             :style="{backgroundImage: `url(${getMap(project.code, experiment.path)})` }"
           />
+          <!-- <img :src="getMap(project.code, experiment.path)" class="object-contain w-full h-full"> -->
         </div>
       </div>
     </div>

--- a/components/cpm/Explore.vue
+++ b/components/cpm/Explore.vue
@@ -1,11 +1,10 @@
 <template>
-  <div class="flex flex-col w-full h-full">
+  <div class="flex flex-col gap-8 items-center w-full h-full">
     <span class="flex space-x-3 p-3">
       <div>
         <multiselect
           v-model="selectedDomain"
           :options="domains"
-          :searchable="false"
           :allow-empty="false"
           :close-on-select="true"
           :show-labels="false"
@@ -62,12 +61,12 @@
           :clear-on-select="false"
           :preserve-search="true"
           :show-labels="true"
-          placeholder="Choose project(s)"
-          label="name"
+          placeholder="Choose resolution(s)"
+          label="title"
           track-by="name"
           :preselect-first="true"
         >
-          <template slot="selection" slot-scope="{ values, isOpen }"><span v-if="values.length &amp;&amp; !isOpen" class="multiselect__single">{{ values.length }} project(s) selected</span></template>
+          <!-- <template slot="selection" slot-scope="{ values, isOpen }"><span v-if="values.length &amp;&amp; !isOpen" class="multiselect__single">{{ values.length }} project(s) selected</span></template> -->
         </multiselect>
       </div>
       <div>
@@ -79,12 +78,12 @@
           :clear-on-select="false"
           :preserve-search="true"
           :show-labels="true"
-          placeholder="Choose experiment(s)"
+          placeholder="Choose historical or future"
           label="name"
           track-by="name"
           :preselect-first="true"
         >
-          <template slot="selection" slot-scope="{ values, isOpen }"><span v-if="values.length &amp;&amp; !isOpen" class="multiselect__single">{{ values.length }} experiment(s) selected</span></template>
+          <!-- <template slot="selection" slot-scope="{ values, isOpen }"><span v-if="values.length &amp;&amp; !isOpen" class="multiselect__single">{{ values.length }} experiment(s) selected</span></template> -->
         </multiselect>
       </div>
     </span>
@@ -93,24 +92,22 @@
       :key="experiment.path"
       class="w-full h-full"
     >
-      <div class="flex w-full h-full">
-        <p class="text-lg prose">
+      <div class="flex h-full w-full">
+        <p class="flex-none text-lg prose">
           {{ experiment.name }}:
         </p>
         <div
           v-for="project in selectedProject"
           :key="project.code"
-          class="w-1/3 h-full"
-        >
-          <p class="text-center text-lg prose">
-            {{ project.title }}
-          </p>
-          <!-- <div
-            class="bg-no-repeat bg-contain w-auto h-full"
-            :style="{backgroundImage: `url(${getMap(project.code, experiment.path)})` }"
-          /> -->
-          <img :src="getMap(project.code, experiment.path)" class="object-contain w-full h-full">
-        </div>
+          class="bg-no-repeat bg-contain w-full h-full"
+          :style="{backgroundImage: `url(${getMap(project.code, experiment.path)})` }"
+        />
+        <!-- <img
+          v-for="project in selectedProject"
+          :key="project.code"
+          :src="getMap(project.code, experiment.path)"
+          class="object-contain h-full w-full"
+        > -->
       </div>
     </div>
   </div>

--- a/components/cpm/Explore.vue
+++ b/components/cpm/Explore.vue
@@ -3,6 +3,19 @@
     <span class="flex space-x-3 p-3">
       <div>
         <multiselect
+          v-model="selectedDomain"
+          :options="domains"
+          :searchable="false"
+          :allow-empty="false"
+          :close-on-select="true"
+          :show-labels="false"
+          label="name"
+          deselect-label=" "
+          placeholder="Select a domain."
+        />
+      </div>
+      <div>
+        <multiselect
           v-model="selectedVariable"
           :options="variables"
           :searchable="false"
@@ -74,16 +87,6 @@
           <template slot="selection" slot-scope="{ values, isOpen }"><span v-if="values.length &amp;&amp; !isOpen" class="multiselect__single">{{ values.length }} experiment(s) selected</span></template>
         </multiselect>
       </div>
-      <!-- same style but not selectable option to display region -->
-      <select
-        class="border border-gray-300 rounded cursor-pointer
-            text-gray-600 h-10 pl-5 pr-10 bg-white hover:border-gray-300
-            focus:outline-none appearance-none"
-      >
-        <option :value="domain">
-          {{ domain }}
-        </option>
-      </select>
     </span>
     <div
       v-for="experiment in selectedCategory"
@@ -102,11 +105,11 @@
           <p class="text-center text-lg prose">
             {{ project.title }}
           </p>
-          <div
+          <!-- <div
             class="bg-no-repeat bg-contain w-auto h-full"
             :style="{backgroundImage: `url(${getMap(project.code, experiment.path)})` }"
-          />
-          <!-- <img :src="getMap(project.code, experiment.path)" class="object-contain w-full h-full"> -->
+          /> -->
+          <img :src="getMap(project.code, experiment.path)" class="object-contain w-full h-full">
         </div>
       </div>
     </div>
@@ -117,14 +120,9 @@
 import Multiselect from 'vue-multiselect'
 export default {
   components: { Multiselect },
-  props: {
-    domain: {
-      default: 'AL',
-      type: String
-    }
-  },
   data () {
     return {
+      selectedDomain: { name: 'Alps', code: 'AL' },
       selectedVariable: { name: 'Precipitation', code: 'pr' },
       selectedSeason: { name: 'Winter', code: 'DJF' },
       selectedModel: { name: 'CNRM', code: 'cnrm' },
@@ -136,6 +134,15 @@ export default {
       selectedCategory: [
         { name: 'Past performance', path: 'past_performance' },
         { name: 'Future change', path: 'future_change' }
+      ],
+      domains: [
+        { name: 'Alps', code: 'AL' },
+        { name: 'Northern Europe', code: 'N' },
+        { name: 'Northwest Europe', code: 'NW' },
+        { name: 'Central Europe', code: 'C' },
+        { name: 'Central Eastern Europe', code: 'CE' },
+        { name: 'Southwest Europe', code: 'SW' },
+        { name: 'Southeast Europe', code: 'SE' }
       ],
       variables: [
         { name: 'Precipitation', code: 'pr' },
@@ -168,7 +175,7 @@ export default {
   computed: {
     filterModels () {
       const filterList = []
-      this.regionsModels[this.domain].forEach((model) => {
+      this.regionsModels[this.selectedDomain.code].forEach((model) => {
         if (model === 'SMHI') {
           const modelObject = { name: 'DMI/SMHI', code: 'smhi' }
           filterList.push(modelObject)
@@ -181,8 +188,8 @@ export default {
     }
   },
   watch: {
-    domain () {
-      if (!this.regionsModels[this.domain].includes(this.selectedModel.name)) {
+    selectedDomain () {
+      if (!this.regionsModels[this.selectedDomain.code].includes(this.selectedModel.name)) {
         this.selectedModel = this.filterModels[0]
       }
     }
@@ -191,7 +198,7 @@ export default {
     getMap (project, experiment) {
       const fallback = 'empty.png'
       try {
-        return require('~/static/cpm_analysis/' + experiment + '/' + this.domain + '/' + this.selectedVariable.code + '/' + project + '_' + this.selectedModel.code + '_' + this.selectedSeason.code + '.png')
+        return require('~/static/cpm_analysis/' + experiment + '/' + this.selectedDomain.code + '/' + this.selectedVariable.code + '/' + project + '_' + this.selectedModel.code + '_' + this.selectedSeason.code + '.png')
       } catch (err) {
         return fallback
       }

--- a/components/cpm/Map.vue
+++ b/components/cpm/Map.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="mapid" style="height: 600px; width:500px" class="border-4" />
+  <div id="mapid" style="height: 600px; width:500px" class="shadow-inner" />
 </template>
 
 <script>

--- a/content/topical/constrained_projections.md
+++ b/content/topical/constrained_projections.md
@@ -11,11 +11,11 @@ doi: https://doi.org/10.5281/zenodo.5645153
 ---
 
 Outputs from the probabilistic projection methods developed or assessed in the
-European Climate Projection system (EUCP) Horizon2020 project. 
+European Climate Projection system (EUCP) Horizon2020 project.
 <!--more-->
 The data can be previewed through our [interactive atlas](https://eucp-project.github.io/atlas/).
 
 For more information, see the [atlas about page](https://eucp-project.github.io/atlas/about), or the corresponding [storyboard](https://eucp-project.github.io/storyboards/atlas/1_intro).
 
-### Preview image:
+### Preview image
 ![preview](atlas.png)

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="h-screen w-screen p-4">
-    <div class="flex gap-10 items-center">
+  <div class="flex flex-col h-screen w-screen p-4 overflow-auto">
+    <div class="flex-none flex gap-10 items-center">
       <NuxtLink :to="`/`">
         <img src="eucp_logo.png" alt="EUCP Logo">
       </NuxtLink>
-      <div class="flex-l">
+      <div class="flex-none">
         <h1 class="text-4xl">
           Data Catalogue
         </h1>
@@ -13,7 +13,7 @@
       <Navigation />
     </div>
     <!-- grey background bar for menu -->
-    <div class="bg-gradient-to-r from-transparent via-gray-200 to-gray-200 w-screen h-12" />
-    <Nuxt class="pt-4" />
+    <div class="flex-none bg-gradient-to-r from-transparent via-gray-200 to-gray-200 w-full h-12 rounded" />
+    <Nuxt class="flex-1" />
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -14,6 +14,6 @@
     </div>
     <!-- grey background bar for menu -->
     <div class="flex-none bg-gradient-to-r from-transparent via-gray-200 to-gray-200 w-full h-12 rounded" />
-    <Nuxt class="self-stretch" />
+    <Nuxt class="flex-grow" />
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col h-screen w-screen p-4 overflow-auto">
-    <div class="flex-none flex gap-10 items-center">
+    <div class="flex gap-10 items-center">
       <NuxtLink :to="`/`">
         <img src="eucp_logo.png" alt="EUCP Logo">
       </NuxtLink>
@@ -14,6 +14,6 @@
     </div>
     <!-- grey background bar for menu -->
     <div class="flex-none bg-gradient-to-r from-transparent via-gray-200 to-gray-200 w-full h-12 rounded" />
-    <Nuxt class="flex-1" />
+    <Nuxt class="self-stretch" />
   </div>
 </template>

--- a/pages/cpm.vue
+++ b/pages/cpm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex gap-4 p-2">
+  <div class="flex h-full w-full gap-4 p-2">
     <NuxtChild class="self-stretch" :domain="domain" />
   </div>
 </template>

--- a/pages/cpm.vue
+++ b/pages/cpm.vue
@@ -1,11 +1,7 @@
 <template>
-  <div>
-    <div class="flex gap-4 m-8">
-      <CpmMap v-model="domain" />
-      <div class="border-4 flex-grow">
-        <NuxtChild :domain="domain" />
-      </div>
-    </div>
+  <div class="flex gap-4 p-2">
+    <CpmMap class="flex-none" v-model="domain" />
+    <NuxtChild class="self-stretch" :domain="domain" />
   </div>
 </template>
 

--- a/pages/cpm.vue
+++ b/pages/cpm.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="flex gap-4 p-2">
-    <CpmMap class="flex-none" v-model="domain" />
     <NuxtChild class="self-stretch" :domain="domain" />
   </div>
 </template>

--- a/pages/cpm/download.vue
+++ b/pages/cpm/download.vue
@@ -1,5 +1,17 @@
 <template>
-  <div>
-    <p>download</p>
+  <div class="prose max-w-none">
+    <h1>Data access</h1>
+    <p>
+      We are currently in the process of uploading the data to ESGF. Once the
+      data is available there, we will provide instructions on how to access it.
+    </p>
+
+    <p>
+      We are looking into possibilities of making pre-processed subsets of the data available through zenodo:
+    </p>
+    <ul>
+      <li>Link 1</li>
+      <li>Link 2</li>
+    </ul>
   </div>
 </template>

--- a/pages/cpm/explore.vue
+++ b/pages/cpm/explore.vue
@@ -1,9 +1,3 @@
 <template>
   <CpmExplore :domain="domain" class="w-full h-full" />
 </template>
-
-<script>
-export default {
-  props: ['domain']
-}
-</script>

--- a/pages/cpm/explore.vue
+++ b/pages/cpm/explore.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full p-2">
+  <div class="w-full h-full">
     <CpmExplore :domain="domain" />
   </div>
 </template>

--- a/pages/cpm/explore.vue
+++ b/pages/cpm/explore.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="w-full h-full">
-    <CpmExplore :domain="domain" />
-  </div>
+  <CpmExplore :domain="domain" class="w-full h-full" />
 </template>
 
 <script>

--- a/pages/cpm/index.vue
+++ b/pages/cpm/index.vue
@@ -1,18 +1,52 @@
 <template>
-  <div class="m-2 ml-9 prose">
-    <p>
-      Building upon CORDEX FPS-Convection, EUCP has performed
-      convection-permitting model runs for multiple domains covering Europe and
-      the outermost regions. This page provides an overview of the most relevant
-      data and results from our preliminary analysis. Select a region on the map
-      to start exploring.
-    </p>
-    <p> You selected the following domain: {{ domain }}</p>
+  <div class="flex w-full gap-4 p-2">
+    <CpmMap v-model="domain" class="flex-none" />
+    <div class="flex-grow p-4 prose max-w-none" :domain="domain">
+      <h1>EUCP convection permitting model simulations</h1>
+      <p>
+        Building upon CORDEX FPS-Convection, EUCP has performed
+        convection-permitting model runs for multiple domains covering Europe
+        and the outermost regions. This page provides an overview of the most
+        relevant data and results from our preliminary analysis. Select a region
+        on the map to start exploring.
+      </p>
+      <p>
+        The selected domain is: <strong>{{ domainNames[domain] }}</strong>.
+        For this domain, data from the following groups/models is available:
+        <ul>
+          <li v-for="(group, i) in groups[domain]" :key="i">
+            {{ group }}
+          </li>
+        </ul>
+      </p>
+    </div>
   </div>
 </template>
 
 <script>
 export default {
-  props: ['domain']
+  data () {
+    return {
+      domain: 'AL', // default value for domain
+      domainNames: {
+        N: 'Northern Europe',
+        NW: 'Northwest Europe',
+        C: 'Central Europe',
+        SW: 'Southwest Europe',
+        SE: 'Southeast Europe',
+        CE: 'Central Eastern Europe',
+        AL: 'Alps'
+      },
+      groups: {
+        NW: ['CNRM', 'KNMI', 'ETHZ', 'UKMO'],
+        SW: ['CMCC', 'IPSL', 'ETHZ', 'UKMO'],
+        SE: ['ICTP', 'ETHZ', 'UKMO'],
+        C: ['GERICS', 'ETHZ', 'UKMO'],
+        CE: ['SMHI', 'ICTP', 'ETHZ', 'UKMO'],
+        N: ['SMHI', 'GERICS'],
+        AL: ['CNRM', 'CMCC', 'IPSL', 'KNMI', 'GERICS', 'ETHZ', 'SMHI', 'ICTP', 'UKMO']
+      }
+    }
+  }
 }
 </script>

--- a/pages/cpm/references.vue
+++ b/pages/cpm/references.vue
@@ -1,46 +1,48 @@
 <template>
-  <div class="p-3">
-    <div v-if="domain == 'default'">
-      <p>Read more about the stories in the regions highlighted on the map:</p>
-      <div
-        v-for="(stories, i) in storyboards"
-        :key="i"
-      >
-        <p
-          v-for="(story, j) in stories"
-          :key="j"
-          class="m-3 p-2 hover:underline italic font-medium"
-        >
-          <a :href="story.link" target="_blank">{{ story.title }}</a>
-        </p>
-      </div>
-    </div>
-    <div v-else>
-      <p>Read more about the stories in this region:</p>
-      <div
-        v-for="(story, i) in storyboards[domain]"
-        :key="i"
-        class="m-3 p-2 hover:underline italic font-medium"
-      >
-        <p>
-          <a :href="story.link" target="_blank">{{ story.title }}</a>
-        </p>
-      </div>
-    </div>
+  <div class="p-4 prose max-w-none">
+    <h1>In-depth analyses and example applications</h1>
+    <h2>Storyboards</h2>
+    <p>These storyboards incorporate convection-permitting model output:</p>
+    <ul>
+      <li v-for="(story, i) in stories" :key="`story_${i}`">
+        <a :href="story.link" target="_blank">{{ story.title }}</a>
+      </li>
+    </ul>
+    <h2>Journal publications</h2>
+    <p>
+      These publications deal with convection-permitting model data. Links
+      point to the EUCP project site which features nice summaries.
+    </p>
+    <ul>
+      <li v-for="(publication, i) in stories" :key="`paper_${i}`">
+        <a :href="publication.link" target="_blank">{{ publication.title }}</a>
+      </li>
+    </ul>
+    <div class="h-12 mb-4" />
   </div>
 </template>
 
 <script>
 export default {
-  async asyncData (context) {
-    const storyboards = await context.$content('storyboards')
-      .sortBy('sort')
-      .fetch()
-    return { storyboards: storyboards.stories }
-  },
   data () {
     return {
-      domain: 'default' // default value for domain to display all storyboards
+      stories: [
+        { title: 'Attribution of a small scale, heavy flash flood event to climate change', link: 'https://eucp-project.github.io/storyboards/flood' },
+        { title: 'Benefits and added value of convection-permitting climate modeling over Fenno-Scandinavia', link: 'https://eucp-project.github.io/storyboards/cp_benefits' },
+        { title: 'Alpine flash floods', link: 'https://eucp-project.github.io/storyboards/flashflood' },
+        { title: 'The EUCP Caribbean runs', link: 'https://eucp-project.github.io/storyboards/carribean' },
+        { title: 'Identification of historic "Heavy Precipitation Events" using a tracking algorithm', link: 'https://eucp-project.github.io/storyboards/heavy_precip' }
+        // { title: '', link: '' }
+      ],
+      publications: [
+        { title: 'Extreme windstorms and sting jets in convection-permitting climate simulations over Europe', link: 'https://www.eucp-project.eu/publications/extreme-windstorms-and-sting-jets-in-convection-permitting-climate-simulations-over-europe/' },
+        { title: 'Convection-permitting modeling with regional climate models: Latest developments and next steps', link: 'https://www.eucp-project.eu/publications/convection-permitting-modeling-with-regional-climate-models-latest-developments-and-next-steps/' },
+        { title: 'The first multi-model ensemble of regional climate simulations at kilometer-scale resolution part 1: evaluation of precipitation', link: 'https://www.eucp-project.eu/publications/the-first-multi-model-ensemble-of-regional-climate-simulations-at-kilometer-scale-resolution-part-1-evaluation-of-precipitation/' },
+        { title: 'The first multi-model ensemble of regional climate simulations at kilometer-scale resolution part 2: historical and future simulations of precipitation', link: 'https://www.eucp-project.eu/publications/the-first-multi-model-ensemble-of-regional-climate-simulations-at-kilometer-scale-resolution-part-2-historical-and-future-simulations-of-precipitation/' },
+        { title: 'Europe-wide precipitation projections at convection permitting scale with the Unified Model', link: 'https://www.eucp-project.eu/publications/europe-wide-climate-change-projections-at-convection-permitting-scale-with-the-unified-model/' },
+        { title: 'A first-of-its-kind multi-model convection permitting ensemble for investigating convective phenomena over Europe and the Mediterranean', link: 'https://www.eucp-project.eu/publications/a-first-of-its-kind-multi-model/' }
+        // { title: '', link: '' }
+      ]
     }
   }
 }

--- a/pages/decadal/_page.vue
+++ b/pages/decadal/_page.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="flex gap-8 justify-start">
-    <div class="relative">
-      <nuxt-content :document="page" class="prose" />
-      <a :href="urlGitHub(page.path, page.extension)" target="_blank" class="absolute block top-0 right-0 transform -translate-y-full">
+  <div class="flex gap-8 items-stretch">
+    <div class="relative w-2/3">
+      <nuxt-content :document="page" class="prose max-w-none" />
+      <a :href="urlGitHub(page.path, page.extension)" target="_blank" class="absolute block bottom-0 right-0">
         <svg class="h-6 float-left border-4 border-gray-200 bg-gray-200 rounded" viewBox="0 0 134 16">
           <path fill="#000000" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z" />
           <text x="26" y="14">Edit on GitHub</text>
         </svg>
       </a>
     </div>
-    <div class="flex flex-col">
-      <img :src="page.img" alt="topic picture" style="width:auto;height:800px;object-fit: contain">
+    <div class="flex flex-col w-1/3">
+      <img :src="page.img" alt="topic picture">
       <p class="italic">
         {{ page.caption }}
       </p>

--- a/pages/decadal/index.vue
+++ b/pages/decadal/index.vue
@@ -5,5 +5,11 @@
       EUCP has contributed to the advancement of decadal prediction. This page
       provides an overview of the main data outcomes of this work.
     </p>
+    <p>Use the menu or the following links to learn more about:</p>
+    <ul>
+      <li><NuxtLink to="/decadal/forecasts">Forecasts</NuxtLink></li>
+      <li><NuxtLink to="/decadal/hindcasts">Hindcasts</NuxtLink></li>
+      <li><NuxtLink to="/decadal/experiments">Experiments</NuxtLink></li>
+    </ul>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,33 +7,36 @@
       sources and provides additional context and documentation.
     </div>
     <!-- Buttons -->
-    <div class="self-stretch flex gap-12 items-stretch">
-      <NuxtLink to="cpm" class="flex flex-col group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
-        <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
+    <div class="flex-grow flex gap-12 items-stretch">
+      <NuxtLink to="cpm" class="flex flex-col items-stretch h-full group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
+        <div class="rounded-tl-lg rounded-tr-lg py-4 text-center text-3xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
           CPM data
         </div>
         <p class="prose p-4 max-w-none">
-          Output data from convection permitting model (CPM) runs.
+          Output data from convection permitting model (CPM) simulations.
         </p>
-        <img src="domains.jpg" alt="domains" class="object-contain h-full w-auto mx-auto">
+        <!-- <img src="domains.jpg" alt="domains" class="object-contain h-full w-auto mx-auto"> -->
+        <div :style="{ backgroundImage: `url('domains.jpg')` }" class="bg-center bg-no-repeat bg-contain w-full h-full" />
       </NuxtLink>
-      <NuxtLink to="decadal" class="flex flex-col group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
-        <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
+      <NuxtLink to="decadal" class="flex flex-col items-stretch h-full group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
+        <div class="rounded-tl-lg rounded-tr-lg py-4 text-center text-3xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
           Decadal
         </div>
         <p class="prose p-4 max-w-none">
           Climate model output from decadal prediction runs, contributing to the CMIP6 project DCPP.
         </p>
-        <img src="decadal_forecast.png" alt="decadal forecast" class="object-contain h-full w-auto mx-auto">
+        <!-- <img src="decadal_forecast.png" alt="decadal forecast" class="object-contain h-full w-auto mx-auto"> -->
+        <div :style="{ backgroundImage: `url('decadal_forecast.png')` }" class="bg-center bg-no-repeat bg-contain w-full h-full" />
       </NuxtLink>
-      <NuxtLink to="topical" class="flex flex-col group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
-        <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
+      <NuxtLink to="topical" class="flex flex-col items-stretch h-full group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
+        <div class="rounded-tl-lg rounded-tr-lg py-4 text-center text-3xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
           Topical
         </div>
         <p class="prose p-4 max-w-none">
           This page contains information on smaller topical datasets that resulted from multiple research activities.
         </p>
-        <img src="shoreline_retreat.png" alt="shoreline retreat" class="object-contain h-full w-auto mx-auto">
+        <!-- <img src="shoreline_retreat.png" alt="shoreline retreat" class="object-contain h-full w-auto mx-auto"> -->
+        <div :style="{ backgroundImage: `url('shoreline_retreat.png')` }" class="bg-center bg-no-repeat bg-contain w-full h-full" />
       </NuxtLink>
     </div>
     <div class="prose max-w-none p-8 text-center text-xs">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col p-24">
+  <div class="px-12 pt-8 flex flex-col">
     <div class="prose max-w-none w-2/3 mb-4 text-gray-700 leading-7 pb-8">
       One of the important outcomes of the EUCP (European Climate Prediction system) project is data.
       This data catalogue was developed to provide an overview of all data outputs of the project.
@@ -7,40 +7,34 @@
       sources and provides additional context and documentation.
     </div>
     <!-- Buttons -->
-    <div class="flex gap-12">
-      <div class="group flex flex-col shadow-xl w-1/3 rounded-bl-lg rounded-br-lg filter hover:grayscale-80">
-        <NuxtLink to="cpm">
-          <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
-            CPM data
-          </div>
-          <p class="prose p-4 max-w-none">
-            Output data from convection permitting model (CPM) runs.
-          </p>
-          <img src="domains.jpg" alt="domains" class="object-contain px-6 mx-auto">
-        </NuxtLink>
-      </div>
-      <div class="group flex flex-col shadow-xl w-1/3 rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80">
-        <NuxtLink to="decadal">
-          <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
-            Decadal
-          </div>
-          <p class="prose p-4 max-w-none">
-            Climate model output from decadal prediction runs, contributing to the CMIP6 project DCPP.
-          </p>
-          <img src="decadal_forecast.png" alt="decadal forecast" class="object-contain px-6 mx-auto">
-        </NuxtLink>
-      </div>
-      <div class="group flex flex-col shadow-xl w-1/3 rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80">
-        <NuxtLink to="topical">
-          <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
-            Topical
-          </div>
-          <p class="prose p-4 max-w-none">
-            This page contains information on smaller topical datasets that resulted from multiple research activities.
-          </p>
-          <img src="shoreline_retreat.png" alt="shoreline retreat" class="object-contain px-6 mx-auto">
-        </NuxtLink>
-      </div>
+    <div class="self-stretch flex gap-12 items-stretch">
+      <NuxtLink to="cpm" class="flex flex-col group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
+        <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
+          CPM data
+        </div>
+        <p class="prose p-4 max-w-none">
+          Output data from convection permitting model (CPM) runs.
+        </p>
+        <img src="domains.jpg" alt="domains" class="object-contain h-full w-auto mx-auto">
+      </NuxtLink>
+      <NuxtLink to="decadal" class="flex flex-col group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
+        <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
+          Decadal
+        </div>
+        <p class="prose p-4 max-w-none">
+          Climate model output from decadal prediction runs, contributing to the CMIP6 project DCPP.
+        </p>
+        <img src="decadal_forecast.png" alt="decadal forecast" class="object-contain h-full w-auto mx-auto">
+      </NuxtLink>
+      <NuxtLink to="topical" class="flex flex-col group shadow-xl rounded-bl-lg rounded-br-lg pb-7 filter hover:grayscale-80 w-1/3">
+        <div class="rounded-tl-lg rounded-tr-lg py-6 text-center text-4xl text-white font-extralight tracking-wide bg-blue-900 group-hover:bg-gray-500">
+          Topical
+        </div>
+        <p class="prose p-4 max-w-none">
+          This page contains information on smaller topical datasets that resulted from multiple research activities.
+        </p>
+        <img src="shoreline_retreat.png" alt="shoreline retreat" class="object-contain h-full w-auto mx-auto">
+      </NuxtLink>
     </div>
     <div class="prose max-w-none p-8 text-center text-xs">
       This page is open source. <a href="https://github.com/eucp-project/data-catalogue" target="_blank" rel="noopener">Edit on github</a>.

--- a/pages/topical.vue
+++ b/pages/topical.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="h-full w-full">
+  <div class="flex flex-col gap-8 p-8">
     <!-- brief summary -->
-    <p class="m-2 ml-9 text-lg prose max-w-none">
+    <p class="text-lg prose max-w-none">
       This page provides an overview of datasets that have been produced in EUCP on a variety of applications.
     </p>
     <!-- search -->
@@ -9,32 +9,34 @@
     <input
       v-model="query"
       type="search"
-      class="border-2 border-gray-400 rounded-l w-1/3 m-3 ml-8 p-2"
+      class="border-2 border-gray-400 rounded-l w-1/3"
       placeholder="search"
     >
     </input>
     <!-- eslint-enable -->
     <!-- flashcard -->
-    <div class="grid grid-cols-3 gap-4 p-8 w-full">
+    <div class="grid grid-cols-3 2xl:grid-cols-4 justify-items-stretch gap-4">
       <div
         v-for="dataset in datasets"
         :key="dataset.title"
-        class="border-4 p-4 prose space-y-0.5"
+        class="shadow-lg rounded prose"
         role="button"
         @click="updateModal(dataset)"
       >
-        <h2>
+        <h2 class="bg-blue-200 rounded-tl-lg rounded-tr-lg p-4">
           {{ dataset.title }}
         </h2>
-        <p>
-          {{ dataset.description }}
-        </p>
-        <ul class="space-y-0.5">
-          <li>Contact: {{ dataset.contact[0].name }}</li>
-          <li class="break-words">
-            Data access: <a :href="dataset.doi" target="blank">{{ dataset.doi }}</a>
-          </li>
-        </ul>
+        <div class="prose px-6 pb-2">
+          <p>
+            {{ dataset.description }}
+          </p>
+          <ul class="">
+            <li>Contact: {{ dataset.contact[0].name }}</li>
+            <li class="break-words">
+              Data access: <a :href="dataset.doi" target="blank">{{ dataset.doi }}</a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <Modal


### PR DESCRIPTION
- Set overflow-auto on the main layout page to prevent horizontal scrollbars
- Make home page fit to the screen
- Only show leaflet map on CPM home page (use dropdown in explorer)
- CPM explore images scale down to fit page
- Improved naming of CPM explorer dropdowns
- Pimp CPM analyse page
- Polished CPM reference page
- More styling of the topical dataset cards and modal
- Improved layout of decadal pages
- Fix duplicate key error in navigation